### PR TITLE
Namespace

### DIFF
--- a/3.3/main.cpp
+++ b/3.3/main.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
 
+using namespace std;
 
 int main() {
-    std::cout << "Hello, World!" << std::endl;
+    cout << "Hello, World!" << endl;
     return 0;
 }


### PR DESCRIPTION
Wen du "using namespace std;" unterhalb der #includes eingibst, brauchst du das "std::" nicht mehr vor cout etc zu schreiben.
